### PR TITLE
Add command line arguments for `login` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.26",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",
+        "@inquirer/prompts": "^5.2.0",
         "@napi-rs/keyring": "^1.1.3",
         "axios": "^1.4.0",
         "chalk": "^4.1.2",
@@ -1043,6 +1044,251 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.0.tgz",
+      "integrity": "sha512-XHOCmntitRBD8SJcrv+6X9YakxO1wfsvezOnU5MBIXeTlSBRCVk9DOIrx6Cgi9BS3qkcy7oQb+fUGEKrP6xecQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.15.tgz",
+      "integrity": "sha512-CiLGi3JmKGEsia5kYJN62yG/njHydbYIkzSBril7tCaKbsnIqxa2h/QiON9NjfwiKck/2siosz4h7lVhLFocMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-p2BRZv/vMmpwlU4ZR966vKQzGVCi4VhLjVofwnFLziTQia541T7i1Ar8/LPh+LzjkXzocme+g5Io6MRtzlCcNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.14.11",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.15.tgz",
+      "integrity": "sha512-UmtZnY36rGLS/4cCzvdRmk0xxsGgH2AsF0v1SSlBZ3C5JK/Bxm2gNW8fmUVzQ5vm8kpdWASXPapbUx4iV49ScA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.15.tgz",
+      "integrity": "sha512-aBnnrBw9vbFJROUlDCsbq8H/plX6JHfPwLmSphxaVqOR+b1hgLdw+oRhZkpcJhG2AZOlc8IKzGdZhji93gQg4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+      "integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.2.tgz",
+      "integrity": "sha512-VjkzYSVH0606nLi9HHiSb4QYs2idwRgneiMoFoTAIwQ1Qwx6OIDugOYLtLta3gP8AWZx7qUvgDtj+/SJuiiKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.3.tgz",
+      "integrity": "sha512-GLTuhuhzK/QtB7BhM2pLJGKsv366kv237iNF8hTEOx+EGmXsPNGTydAgZmcuVizEmgC9VSVh1S0memXnIUTYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.15.tgz",
+      "integrity": "sha512-/JmiTtIcSYbZdPucEW5q2rhC71vGKPivm3LFqNDQEI6lJyffq7hlfKKFC+R1Qp19dMqkaG+O5L1XmcHpmlAUUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.2.0.tgz",
+      "integrity": "sha512-7jBWrlkvprEHEFw29zG/piw/M76c5/zYQWfi8ybHeyzcTuXkh1NjDQxLg2PiruvsIt36z1zvKM5yn7vbF0Yr/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.4.0",
+        "@inquirer/confirm": "^3.1.15",
+        "@inquirer/editor": "^2.1.15",
+        "@inquirer/expand": "^2.1.15",
+        "@inquirer/input": "^2.2.2",
+        "@inquirer/number": "^1.0.3",
+        "@inquirer/password": "^2.1.15",
+        "@inquirer/rawlist": "^2.1.15",
+        "@inquirer/select": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.15.tgz",
+      "integrity": "sha512-zwU6aWDMyuQNiY5Z0iYXkxi7pliRFXqUmiS7vG6lAGxqcbOSptYgIxGJnd3AU4Y91N0Tbt57+koJL0S2p6vSkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.0.tgz",
+      "integrity": "sha512-iU1eRkHirVNs43zWk6anMIMKc7tCXlJ+I5DcpIV7JzMe+45TuPPOGGCgeGIkZ4xYJ3cXdFoh7GJpm84PNC8veg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+      "integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2183,11 +2429,23 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
-      "devOptional": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2252,11 +2510,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3443,9 +3708,10 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -9647,6 +9913,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10022,6 +10294,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10756,6 +11040,180 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@inquirer/checkbox": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.0.tgz",
+      "integrity": "sha512-XHOCmntitRBD8SJcrv+6X9YakxO1wfsvezOnU5MBIXeTlSBRCVk9DOIrx6Cgi9BS3qkcy7oQb+fUGEKrP6xecQ==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/confirm": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.15.tgz",
+      "integrity": "sha512-CiLGi3JmKGEsia5kYJN62yG/njHydbYIkzSBril7tCaKbsnIqxa2h/QiON9NjfwiKck/2siosz4h7lVhLFocMQ==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      }
+    },
+    "@inquirer/core": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-p2BRZv/vMmpwlU4ZR966vKQzGVCi4VhLjVofwnFLziTQia541T7i1Ar8/LPh+LzjkXzocme+g5Io6MRtzlCcNA==",
+      "requires": {
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.14.11",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "dependencies": {
+        "cli-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
+        },
+        "mute-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@inquirer/editor": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.15.tgz",
+      "integrity": "sha512-UmtZnY36rGLS/4cCzvdRmk0xxsGgH2AsF0v1SSlBZ3C5JK/Bxm2gNW8fmUVzQ5vm8kpdWASXPapbUx4iV49ScA==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "external-editor": "^3.1.0"
+      }
+    },
+    "@inquirer/expand": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.15.tgz",
+      "integrity": "sha512-aBnnrBw9vbFJROUlDCsbq8H/plX6JHfPwLmSphxaVqOR+b1hgLdw+oRhZkpcJhG2AZOlc8IKzGdZhji93gQg4w==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/figures": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+      "integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ=="
+    },
+    "@inquirer/input": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.2.tgz",
+      "integrity": "sha512-VjkzYSVH0606nLi9HHiSb4QYs2idwRgneiMoFoTAIwQ1Qwx6OIDugOYLtLta3gP8AWZx7qUvgDtj+/SJuiiKuQ==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      }
+    },
+    "@inquirer/number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.3.tgz",
+      "integrity": "sha512-GLTuhuhzK/QtB7BhM2pLJGKsv366kv237iNF8hTEOx+EGmXsPNGTydAgZmcuVizEmgC9VSVh1S0memXnIUTYzQ==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      }
+    },
+    "@inquirer/password": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.15.tgz",
+      "integrity": "sha512-/JmiTtIcSYbZdPucEW5q2rhC71vGKPivm3LFqNDQEI6lJyffq7hlfKKFC+R1Qp19dMqkaG+O5L1XmcHpmlAUUQ==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2"
+      }
+    },
+    "@inquirer/prompts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.2.0.tgz",
+      "integrity": "sha512-7jBWrlkvprEHEFw29zG/piw/M76c5/zYQWfi8ybHeyzcTuXkh1NjDQxLg2PiruvsIt36z1zvKM5yn7vbF0Yr/A==",
+      "requires": {
+        "@inquirer/checkbox": "^2.4.0",
+        "@inquirer/confirm": "^3.1.15",
+        "@inquirer/editor": "^2.1.15",
+        "@inquirer/expand": "^2.1.15",
+        "@inquirer/input": "^2.2.2",
+        "@inquirer/number": "^1.0.3",
+        "@inquirer/password": "^2.1.15",
+        "@inquirer/rawlist": "^2.1.15",
+        "@inquirer/select": "^2.4.0"
+      }
+    },
+    "@inquirer/rawlist": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.15.tgz",
+      "integrity": "sha512-zwU6aWDMyuQNiY5Z0iYXkxi7pliRFXqUmiS7vG6lAGxqcbOSptYgIxGJnd3AU4Y91N0Tbt57+koJL0S2p6vSkA==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/select": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.0.tgz",
+      "integrity": "sha512-iU1eRkHirVNs43zWk6anMIMKc7tCXlJ+I5DcpIV7JzMe+45TuPPOGGCgeGIkZ4xYJ3cXdFoh7GJpm84PNC8veg==",
+      "requires": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      }
+    },
+    "@inquirer/type": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+      "integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
+      "requires": {
+        "mute-stream": "^1.0.0"
+      },
+      "dependencies": {
+        "mute-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="
+        }
+      }
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -11623,11 +12081,21 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
-      "devOptional": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -11691,10 +12159,15 @@
         }
       }
     },
+    "@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
+    },
     "@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -12494,9 +12967,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="
     },
     "cli-width": {
       "version": "3.0.0",
@@ -17015,6 +17488,11 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -17282,6 +17760,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/tryretool/retool-cli#readme",
   "dependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@inquirer/prompts": "^5.2.0",
     "@napi-rs/keyring": "^1.1.3",
     "axios": "^1.4.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
# What

This pull request adds the following command line arguments to `retool login` command. When they are specified, corresponding questions will be skipped as answered as specified.

```
$ ./lib/index.js login --help                                                              
index.js login

Log in to Retool.

Options:
  --help          Show help                                            [boolean]
  --version       Show version number                                  [boolean]
  --access-token  Specify access token to use for Cookie login          [string]
  --email         Specify user email for email / localhost login        [string]
  --force         Re-authenticate even when already logged in          [boolean]
  --login-method  Specify login method
                  [string] [choices: "browser", "email", "cookies", "localhost"]
  --origin        Specify the login origin host                         [string]
  --password      Specify password for email / localhost login          [string]
  --xsrf-token    Specify XSRF token to use for Coookie login           [string]
```

Questions are rewritten to use [@inquirer/prompts](https://www.npmjs.com/package/@inquirer/prompts) to fully benefit from the TypeScript type system so that the codes get shorter and cleaner.

# Why

It's convenient to skip some questions when the answer is always same for the user or the user is trying to automate (some of) inputs.

# How tested

- [x] `./lib/index.js login --login-method browser` launches the web browser.
- [x] `./lib/index.js login --login-method browser` can skip some or all questions when their answers are given via the command line arguments.
- [x] `./lib/index.js login --login-method cookies` successfully authenticates when some or all answers are given via the command line arguments.