### PR TITLE
Fix typo in `--xsrf-token` description

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -56,7 +56,7 @@ const builder = createBuilder({
     type: "string",
   },
   "xsrf-token": {
-    describe: "Specify XSRF token to use for Coookie login",
+    describe: "Specify XSRF token to use for Cookie login",
     type: "string",
   },
 });


### PR DESCRIPTION
# What

This change fixes a typo in `--xsrf-token` description I made in my previous pull request #20.

# Why

A typo doesn't look professional.

# How tested

The typo is fixed in the help.

```
$ ./lib/index.js login --help                                                                                                    
index.js login

Log in to Retool.

Options:
  --help          Show help                                            [boolean]
  --version       Show version number                                  [boolean]
  --access-token  Specify access token to use for Cookie login          [string]
  --email         Specify user email for email / localhost login        [string]
  --force         Re-authenticate even when already logged in          [boolean]
  --login-method  Specify login method
                  [string] [choices: "browser", "email", "cookies", "localhost"]
  --origin        Specify the login origin host                         [string]
  --password      Specify password for email / localhost login          [string]
  --xsrf-token    Specify XSRF token to use for Cookie login            [string]
```