### PR TITLE
Output `retool apps` errors to `stderr`

### DIFF
--- a/src/utils/apps.ts
+++ b/src/utils/apps.ts
@@ -50,10 +50,11 @@ export async function createApp(
 
   const { page } = createAppResult.data;
   if (!page?.uuid) {
-    console.log("Error creating app.");
-    console.log(createAppResult.data);
+    console.error("Error creating app.");
+    console.error(createAppResult.data);
     process.exit(1);
-  } else {
+  }
+
     console.log("Successfully created an App. 🎉");
     console.log(
       `${chalk.bold("View in browser:")} ${credentials.origin}/editor/${
@@ -62,7 +63,6 @@ export async function createApp(
     );
     return page;
   }
-}
 
 export async function createAppForTable(
   appName: string,
@@ -85,10 +85,11 @@ export async function createAppForTable(
 
   const { pageUuid } = createAppResult.data;
   if (!pageUuid) {
-    console.log("Error creating app.");
-    console.log(createAppResult.data);
+    console.error("Error creating app.");
+    console.error(createAppResult.data);
     process.exit(1);
-  } else {
+  }
+
     console.log("Successfully created an App. 🎉");
     console.log(
       `${chalk.bold("View in browser:")} ${
@@ -96,7 +97,6 @@ export async function createAppForTable(
       }/editor/${pageUuid}`
     );
   }
-}
 
 export async function exportApp(appName: string, credentials: Credentials) {
   // Verify that the provided appName exists.
@@ -107,7 +107,7 @@ export async function exportApp(appName: string, credentials: Credentials) {
     }
   });
   if (app?.length != 1) {
-    console.log(`0 or >1 Apps named ${appName} found. 😓`);
+    console.error(`0 or >1 Apps named ${appName} found. 😓`);
     process.exit(1);
   }
 
@@ -161,7 +161,7 @@ export async function deleteApp(
     }
   });
   if (app?.length != 1) {
-    console.log(`0 or >1 Apps named ${appName} found. 😓`);
+    console.error(`0 or >1 Apps named ${appName} found. 😓`);
     process.exit(1);
   }
 
@@ -209,7 +209,7 @@ export async function collectAppName(): Promise<string> {
   ]);
 
   if (appName.length === 0) {
-    console.log("Error: App name cannot be blank.");
+    console.error("Error: App name cannot be blank.");
     process.exit(1);
   }
 


### PR DESCRIPTION
# What

Use `console.error` instead of `console.log` to output errors of `retool apps`.

# Why

I'm thinking of adding `--json` option to `retool apps` for outputting results in JSON. For that, it's important to differentiate standard outputs from errors. As the initial step, this change replaces all `console.log` outputting errors with `console.error` to redirect error messages to `stderr`, not `stdout`.

In addition, `console.error` renders messages in red, so errors stand out more.

# How tested

An error message is rendered in red when `stdout` is redirected to /dev/null.

```bash
$ yes | ./lib/index.js apps --delete non_existing_app > /dev/null
0 or >1 Apps named non_existing_app found. 😓
```