### PR TITLE
[feat] Add `terraform` command

### DIFF
--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+
+import ora from "ora";
+import { CommandModule } from "yargs";
+
+import { logDAU } from "../utils/telemetry";
+import { importRetoolConfig } from "../utils/terraformGen";
+
+const command: CommandModule["command"] = "terraform";
+const describe: CommandModule["describe"] = `Generate Terraform configuration for the given Retool organization.
+
+This command requires the following environment variables to be set:
+- RETOOL_ACCESS_TOKEN: Access token for the Retool API. The token must have "source_control:read","groups:read","spaces:read","folders:read","permissions:all:read" scopes.
+- RETOOL_HOST: The Retool host domain (e.g. your-org.retool.com).
+You can also set the environment variable RETOOL_SCHEME to "http" if you are using HTTP.`;
+const builder: CommandModule["builder"] = {
+  imports: {
+    alias: "i",
+    describe: `Path of the output file with "import" blocks in it`,
+  },
+};
+
+const handler = async function (argv: any) {
+  // fire and forget
+  void logDAU();
+
+  if (!process.env.RETOOL_ACCESS_TOKEN || !process.env.RETOOL_HOST) {
+    console.error("This command requires RETOOL_ACCESS_TOKEN and RETOOL_HOST environment variables to be set.");
+    process.exit(1);
+  }
+
+  if (!argv.imports) {
+    console.error("Please provide an output file path using --imports flag.");
+    process.exit(1);
+  }
+
+  const spinner = ora("Reading Retool configuration").start();
+  const config = await importRetoolConfig();
+  spinner.stop();
+
+  if (argv.imports) {
+    // Print everything into a file
+    const fileContent = config.map((im) => {
+      return `
+import {
+  to = ${im.resourceType}.${im.terraformId}
+  id = "${im.id}"
+}
+`
+    }).join("");
+    fs.writeFileSync(argv.imports, fileContent);
+  
+    console.log("Generated Terraform file with `import` blocks.");
+  }
+};
+
+const commandModule: CommandModule = {
+  command,
+  describe,
+  builder,
+  handler,
+};
+
+export default commandModule;

--- a/src/utils/networking.ts
+++ b/src/utils/networking.ts
@@ -41,9 +41,9 @@ export async function postRequest(
   }
 }
 
-export async function getRequest(url: string, exitOnFailure = true) {
+export async function getRequest(url: string, exitOnFailure = true, headers = {}) {
   try {
-    const response = await axios.get(url);
+    const response = await axios.get(url, { headers });
     return response;
   } catch (error: any) {
     handleError(error, exitOnFailure, url);

--- a/src/utils/terraformGen.ts
+++ b/src/utils/terraformGen.ts
@@ -1,0 +1,210 @@
+import { getRequest } from "./networking";
+
+const sanitizeUnicodeName = (name: string): string => {
+  return name
+    .normalize('NFKD') // Normalize Unicode
+    .replace(/[^\w\s-]/g, '') // Remove non-alphanumeric characters
+    .replace(/\s+/g, '_') // Replace spaces with underscores
+    .toLowerCase(); // Convert to lowercase
+};
+
+const API_URL_PREFIX = `${process.env.RETOOL_SCHEME ?? 'https'}://${process.env.RETOOL_HOST}/api/v2`;
+const AUTHORIZATION_HEADER = { Authorization: `Bearer ${process.env.RETOOL_ACCESS_TOKEN}` };
+
+const FOLDER_TERRAFORM_IDS = new Set<string>();
+const GROUP_TERRAFORM_IDS = new Set<string>();
+const GROUP_ID_TO_TERRAFORM_ID = new Map<string, string>();
+const SPACE_TERRAFORM_IDS = new Set<string>();
+
+// This type represents any imported terraform resource
+type TerraformResourceImport = {
+  id: string; // The ID of the resource in the Retool database. Can be set to a dummy id for resoures that don't have an ID, like SSO settings.
+  terraformId: string;
+  resourceType: "retool_folder" | "retool_group" | "retool_permissions" | "retool_space" | "retool_source_control" | "retool_source_control_settings" | "retool_sso";
+};
+
+// Ensure that the generated Terraform id is unique - if not, append a sequence number to it
+const makeUniqueTerraformId = (terraformId: string, existingIds: Set<string>): string => {
+  if (existingIds.has(terraformId)) {
+    let seq = 1;
+    while (existingIds.has(`${terraformId}_${seq}`)) {
+      seq++;
+    }
+    terraformId = `${terraformId}_${seq}`;
+  }
+  existingIds.add(terraformId);
+  return terraformId;
+}
+
+// Ensure the terraformId starts with a letter or underscore. We also want to avoid single character terraformIds.
+const isInvalidTerraformId = (terraformId: string): boolean => {
+  return terraformId.length <= 1 || !/^[a-z_]/.test(terraformId);
+}
+
+const generateTerraformIdForFolder = (folderType: string, folderName: string): string => {
+  let terraformId = sanitizeUnicodeName(folderName);
+  if (isInvalidTerraformId(terraformId)) { 
+    terraformId = `${folderType}_folder_${terraformId}`;
+  }
+  return makeUniqueTerraformId(terraformId, FOLDER_TERRAFORM_IDS);
+}
+
+type APIFolder = { 
+  id: string
+  name: string
+  folder_type: string
+  is_system_folder: boolean 
+};
+
+// Read non-system folders from the Retool API and generate Terraform ids for them
+const importFolders = async function (): Promise<TerraformResourceImport[]> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/folders`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  const folders: APIFolder[] = response.data.data;
+  return folders
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .filter((folder) => !folder.is_system_folder)
+    .map((folder) => ({ 
+      id: folder.id, 
+      terraformId: generateTerraformIdForFolder(folder.folder_type, folder.name), 
+      resourceType: "retool_folder" 
+    }));
+}
+
+type APIGroup = {
+  id: number
+  name: string
+};
+
+const generateTerraformIdForGroup = (groupName: string, groupId: string): string => {
+  let terraformId = sanitizeUnicodeName(groupName);
+  if (isInvalidTerraformId(terraformId)) { 
+    terraformId = `group_${terraformId}`;
+  }
+  terraformId = makeUniqueTerraformId(terraformId, GROUP_TERRAFORM_IDS);
+  GROUP_ID_TO_TERRAFORM_ID.set(groupId, terraformId);
+  return terraformId;
+}
+
+const importGroups = async function (): Promise<TerraformResourceImport[]> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/groups`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  const groups: APIGroup[] = response.data.data;
+  return groups
+    .sort((a, b) => a.id - b.id)
+    .filter((group) => !['admin', 'viewer', 'editor', 'All Users'].includes(group.name)) // filter out predefined groups
+    .map((group) => ({ 
+      id: group.id.toString(), 
+      terraformId: generateTerraformIdForGroup(group.name, group.id.toString()), 
+      resourceType: "retool_group" 
+    }));
+}
+
+const importPermissions = function (groupIds: string[]): TerraformResourceImport[] {
+  // We'll just generate imports based on the groups we fetched earlier
+  return groupIds
+    .map((groupId) => ({ 
+      id: `group|${groupId}`, 
+      terraformId: `${GROUP_ID_TO_TERRAFORM_ID.get(groupId)}_permissions`, 
+      resourceType: "retool_permissions" 
+    }));
+}
+
+type APISpace = {
+  id: string
+  name: string
+  domain: string
+};
+
+const generateTerraformIdForSpace = (spaceDomain: string): string => {
+  // the unfortunate thing here is that users can put whatever they want in the domain field, so we have to guard against that
+  let terraformId = spaceDomain
+    .replace(/\./g, '_')
+    .replace(/[^\w\s-]/g, '') // Remove non-alphanumeric characters
+    .replace(/\s+/g, '_') // Replace spaces with underscores
+    .toLowerCase(); // Convert to lowercase
+
+  if (isInvalidTerraformId(terraformId)) { 
+    terraformId = `space_${terraformId}`;
+  }
+  return makeUniqueTerraformId(terraformId, SPACE_TERRAFORM_IDS);
+}
+
+const importSpaces = async function (): Promise<TerraformResourceImport[]> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/spaces`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  const spaces: APISpace[] = response.data.data;
+  return spaces
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((space) => ({ 
+      id: space.id, 
+      terraformId: generateTerraformIdForSpace(space.domain), 
+      resourceType: "retool_space" 
+    }));
+
+  return [];
+}
+
+const importSourceControl = async function (): Promise<TerraformResourceImport[]> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/source_control/config`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  if (!response) {
+    return [];
+  }
+
+  return [{
+    id: "source_control",
+    terraformId: "source_control",
+    resourceType: "retool_source_control"
+  }];
+}
+
+const importSourceControlSettings = function (): TerraformResourceImport[] {
+  return [{
+    id: "source_control_settings",
+    terraformId: "source_control_settings",
+    resourceType: "retool_source_control_settings"
+  }];
+}
+
+const importSSO = async function (): Promise<TerraformResourceImport[]> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/sso/config`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  if (!response) {
+    return [];
+  }
+
+  return [{
+    id: "sso",
+    terraformId: "sso",
+    resourceType: "retool_sso"
+  }];
+}
+
+export const importRetoolConfig = async function (): Promise<TerraformResourceImport[]> {
+  const imports: TerraformResourceImport[] = []
+  imports.push(...(await importFolders()));
+  const groupImports = await importGroups();
+  imports.push(...groupImports);
+  imports.push(...importPermissions(groupImports.map((group) => group.id)));
+  imports.push(...(await importSpaces()));
+  imports.push(...(await importSourceControl()));
+  imports.push(...importSourceControlSettings());
+  imports.push(...(await importSSO()));
+  return imports;
+}


### PR DESCRIPTION
### What
The change adds new command, `terraform`. The command generates "terraform imports" file as described [here](https://docs.google.com/document/d/1vgB1pe_SCAYRAjWfnu2SBdWlKqxq7CBEi2phh22T7ko/edit#heading=h.ged2sq1vb0uy). You can then use the file as an input so that Terraform can auto-generate a config for you.

If you want to try it out on your Retool instance/org, here's how:

1. Generate API token in your org/admin Space as an admin user. Generally, you'd want read & write on spaces, groups, folders, permissions and source control.
2. Set env variables in your console:
```
export RETOOL_HOST=<host name of your instance, e.g. spaces.retool.dev>
export RETOOL_ACCESS_TOKEN=<your API access token>
export RETOOL_SCHEME=<http or https; https is default, so you only need this var if you want to test on local dev> 
```
3. Install Retool CLI from source code of this branch, as described in README.md.
4. Change to the folder where you want your Terraform config to be
5. Run the command:
```
retool terraform -i imports.tf
```
The command may produce `Failed to make request` messages, which you can ignore if they refer to sso or source control API endpoints.
6. Create `main.tf` file with the following contents:
```
terraform {
    required_providers {
        retool = {
            source = "tryretool/retool"
        }
        aws = {
            source  = "hashicorp/aws"
            version = "~> 4.0"
        }
    }
}

provider "retool" {
    host="your instance's hostname here" # e.g. spaces.retool.dev
    scheme="https"
}
```
7. Run `terraform init`
8. Run `terraform plan -generate-config-out=generated_resources.tf` . If there's a lot of stuff in your org, you may hit rate limit. You can set `DISABLE_RATE_LIMIT` env var on the instance to `true` to work around that.

You should now have terraform config for your admin org. See an example for https://spaces.retool.dev [here](https://github.com/tryretool/dzmitry/tree/main/terraform/spaces_import) .