### PR TITLE
[feat] Add an option to `terraform` command to auto-generate Terraform config

### DIFF
--- a/src/utils/terraformGen.ts
+++ b/src/utils/terraformGen.ts
@@ -1,4 +1,4 @@
-import { getRequest } from "./networking";
+import { getRequest, postRequest } from "./networking";
 
 const sanitizeUnicodeName = (name: string): string => {
   return name
@@ -20,8 +20,19 @@ const SPACE_TERRAFORM_IDS = new Set<string>();
 type TerraformResourceImport = {
   id: string; // The ID of the resource in the Retool database. Can be set to a dummy id for resoures that don't have an ID, like SSO settings.
   terraformId: string;
-  resourceType: "retool_folder" | "retool_group" | "retool_permissions" | "retool_space" | "retool_source_control" | "retool_source_control_settings" | "retool_sso";
-};
+} & ({
+  resourceType: "retool_space" | "retool_source_control" | "retool_source_control_settings" | "retool_sso";
+} | 
+{ 
+  resourceType: "retool_folder";
+  folder: APIFolder;
+} | {
+  resourceType: "retool_group";
+  group: APIGroup;
+} | {
+  resourceType: "retool_permissions";
+  groupId: string;
+});
 
 // Ensure that the generated Terraform id is unique - if not, append a sequence number to it
 const makeUniqueTerraformId = (terraformId: string, existingIds: Set<string>): string => {
@@ -54,6 +65,7 @@ type APIFolder = {
   name: string
   folder_type: string
   is_system_folder: boolean 
+  parent_folder_id: string
 };
 
 // Read non-system folders from the Retool API and generate Terraform ids for them
@@ -70,13 +82,24 @@ const importFolders = async function (): Promise<TerraformResourceImport[]> {
     .map((folder) => ({ 
       id: folder.id, 
       terraformId: generateTerraformIdForFolder(folder.folder_type, folder.name), 
-      resourceType: "retool_folder" 
+      resourceType: "retool_folder",
+      folder
     }));
 }
 
 type APIGroup = {
   id: number
   name: string
+  universal_app_access: string
+  universal_resource_access: string
+  universal_workflow_access: string
+  universal_query_library_access: string
+  user_list_access: boolean
+  audit_log_access: boolean
+  unpublished_release_access: boolean
+  usage_analytics_access: boolean
+  account_details_access: boolean
+  landing_page_app_id: string
 };
 
 const generateTerraformIdForGroup = (groupName: string, groupId: string): string => {
@@ -102,7 +125,8 @@ const importGroups = async function (): Promise<TerraformResourceImport[]> {
     .map((group) => ({ 
       id: group.id.toString(), 
       terraformId: generateTerraformIdForGroup(group.name, group.id.toString()), 
-      resourceType: "retool_group" 
+      resourceType: "retool_group",
+      group
     }));
 }
 
@@ -112,7 +136,8 @@ const importPermissions = function (groupIds: string[]): TerraformResourceImport
     .map((groupId) => ({ 
       id: `group|${groupId}`, 
       terraformId: `${GROUP_ID_TO_TERRAFORM_ID.get(groupId)}_permissions`, 
-      resourceType: "retool_permissions" 
+      resourceType: "retool_permissions",
+      groupId
     }));
 }
 
@@ -207,4 +232,148 @@ export const importRetoolConfig = async function (): Promise<TerraformResourceIm
   imports.push(...importSourceControlSettings());
   imports.push(...(await importSSO()));
   return imports;
+}
+
+const getRootFolderIds = async function (): Promise<Map<string, string>> {
+  const response = await getRequest(
+    `${API_URL_PREFIX}/folders`, 
+    false, 
+    AUTHORIZATION_HEADER
+  );
+  const folders: APIFolder[] = response.data.data;
+  const rootFolderIdByType = new Map<string, string>();
+  for (const folder of folders) {
+    if (!folder.parent_folder_id) {
+      rootFolderIdByType.set(folder.folder_type, folder.id);
+    }
+  }
+  return rootFolderIdByType;
+}
+
+export const generateTerraformConfigForFolders = async function (folders: { id: string, terraformId: string, resourceType: "retool_folder", folder: APIFolder}[]): Promise<string[]> {
+  const folderIdToTerraformId = new Map<string, string>();
+  for (const folder of folders) {
+    // technically, we could've used the folder.id directly, since it includes folder type, but I don't want to depend on this
+    folderIdToTerraformId.set(`${folder.folder.folder_type}_${folder.id}`, folder.terraformId);
+  }
+
+  const rootFolderIdByType = await getRootFolderIds();
+  let lines: string[] = [];
+  for (const folder of folders) {
+    const resourceConfigLines = [
+      `resource "retool_folder" "${folder.terraformId}" {`,
+      `  name = "${folder.folder.name}"`,
+      `  folder_type = "${folder.folder.folder_type}"`,
+    ];
+    if (folder.folder.parent_folder_id) {
+      if (folder.folder.parent_folder_id !== rootFolderIdByType.get(folder.folder.folder_type)) {
+        const parentFolderTerraformId = folderIdToTerraformId.get(`${folder.folder.folder_type}_${folder.folder.parent_folder_id}`);
+        resourceConfigLines.push(`  parent_folder_id = retool_folder.${parentFolderTerraformId}.id`);
+      }
+    }
+    resourceConfigLines.push("}");
+    resourceConfigLines.push("");
+    lines = lines.concat(resourceConfigLines);
+  }
+  return lines;
+}
+
+type APIPermissions = {
+  type: string
+  id: string
+  access_level: string
+};
+
+const getPermissionsForGroup = async function (groupId: string): Promise<APIPermissions[]> {
+  let permissions: APIPermissions[] = [];
+  for (const objectType of ["app", "folder", "resource", "resource_configuration"]){
+    const response = await postRequest(
+      `${API_URL_PREFIX}/permissions/listObjects`, 
+      { 
+        subject: {
+          type: "group",
+          id: parseInt(groupId),  
+        },
+        object_type: objectType,
+      },
+      false, 
+      AUTHORIZATION_HEADER
+    );
+    if (!response || !response.data) {
+      console.error(`Failed to fetch permissions for group ${groupId}, object type ${objectType}`);
+    } else {
+      permissions = permissions.concat(response.data.data);  
+    }
+  }
+  return permissions;
+}
+
+export const generateTerraformConfigForGroups = function (groups: { id: string, terraformId: string, resourceType: "retool_group", group: APIGroup}[]): string[] {
+  let lines: string[] = [];
+  for (const group of groups) {
+    const resourceConfigLines = [
+      `resource "retool_group" "${group.terraformId}" {`,
+      `  name = "${group.group.name}"`,
+      `  universal_app_access = "${group.group.universal_app_access}"`,
+      `  universal_resource_access = "${group.group.universal_resource_access}"`,
+      `  universal_workflow_access = "${group.group.universal_workflow_access}"`,
+      `  universal_query_library_access = "${group.group.universal_query_library_access}"`,
+      `  user_list_access = ${group.group.user_list_access}`,
+      `  audit_log_access = ${group.group.audit_log_access}`,
+      `  unpublished_release_access = ${group.group.unpublished_release_access}`,
+      `  usage_analytics_access = ${group.group.usage_analytics_access}`,
+      `  account_details_access = ${group.group.account_details_access}`,
+    ];
+    if (group.group.landing_page_app_id) {
+      resourceConfigLines.push(`  landing_page_app_id = "${group.group.landing_page_app_id}"`);
+    }
+    resourceConfigLines.push("}");
+    resourceConfigLines.push("");
+    lines = lines.concat(resourceConfigLines);
+  }
+  return lines;
+}
+
+export const generateTerraformConfigForPermissions = async function (permissions: { id: string, terraformId: string, resourceType: "retool_permissions", groupId: string}[], allResources: TerraformResourceImport[]): Promise<string[]> {
+  const folderIdToTerraformId = new Map<string, string>();
+  const groupIdToTerraformId = new Map<string, string>();
+  for (const resource of allResources) {
+    if (resource.resourceType === "retool_folder") {
+      folderIdToTerraformId.set(resource.id, resource.terraformId);
+    } else if (resource.resourceType === "retool_group") {
+      groupIdToTerraformId.set(resource.id, resource.terraformId);
+    }
+  }
+  let lines: string[] = [];
+  for (const permission of permissions) {
+    const groupPermissions = await getPermissionsForGroup(permission.groupId);
+    const resourceConfigLines = [
+      `resource "retool_permissions" "${permission.terraformId}" {`,
+      `  subject = {`,
+      `    type = "group"`,
+      `    id = retool_group.${groupIdToTerraformId.get(permission.groupId)}.id`,
+      `  }`,
+      `  permissions = [`,
+    ];
+    for (const groupPermission of groupPermissions) {
+      console.log(groupPermission);
+      resourceConfigLines.push(`    {`);
+      resourceConfigLines.push(`      object = {`);
+      if (groupPermission.type === "folder" && folderIdToTerraformId.has(groupPermission.id)) {
+        resourceConfigLines.push(`        type = "folder"`);
+        resourceConfigLines.push(`        id = retool_folder.${folderIdToTerraformId.get(groupPermission.id)}.id`);
+      } else {
+        resourceConfigLines.push(`        type = "${groupPermission.type}"`);
+        resourceConfigLines.push(`        id = "${groupPermission.id}"`);
+      }
+      resourceConfigLines.push(`      }`);
+      resourceConfigLines.push(`      access_level = "${groupPermission.access_level}"`);
+      resourceConfigLines.push(`    },`);
+    }
+    resourceConfigLines.push("  ]");
+    resourceConfigLines.push("}");
+    resourceConfigLines.push("");
+    lines = lines.concat(resourceConfigLines);
+  }
+  return lines;
 }

--- a/src/utils/terraformGen.ts
+++ b/src/utils/terraformGen.ts
@@ -356,7 +356,6 @@ export const generateTerraformConfigForPermissions = async function (permissions
       `  permissions = [`,
     ];
     for (const groupPermission of groupPermissions) {
-      console.log(groupPermission);
       resourceConfigLines.push(`    {`);
       resourceConfigLines.push(`      object = {`);
       if (groupPermission.type === "folder" && folderIdToTerraformId.has(groupPermission.id)) {


### PR DESCRIPTION
### What
This change adds another option to `terraform` command. If user provides `--config <file name>` option, we'll generate a file with TF resources for them.  They can then use that file to either manage the org that was used to generate the file, or "copy" configuration to a different org. Generated config is "portable", in a sense that we make the best effort to avoid hardcoded object ids and reference other TF resources instead. Note that this PR only includes config generation for `retool_folder`, `retool_group` and `retool_permissions` resources, to keep the PR size manageable. I'll add support for other resources in separate PRs. 

### Implementation choices
I chose to generate the config from scratch, based on Retool API responses. 

An alternative approach would be to use Terraform's `terraform plan -generate-config-out=...` command (described in https://github.com/tryretool/retool-cli/pull/24), then update it to replace hardcoded object ids with references where possible. 

The benefit of relying on Terraform is that we'd get basic file structure and most of the resource attributes "for free", generated by Terraform. So, if we ever add a new attribute or a new resource, we wouldn't necessarily need to update this code, as long as the user is on the latest version of our TF provider.
The downside, however, is that HCL - language used for TF configs - is not particularly friendly for automated modification. We'd have to parse the file somehow, find and update the places that can be switched to reference other resources, then generate an updated file. I started down that path, and the code looked pretty terrible.
The other disadvantage of relying on TF is its handling of default attributes - sometimes TF just doesn't have enough information to decide whether an attribute should be included and set to its default value, or it should be omitted. Generating the config from scratch gives us better control of the output and produces much cleaner and human-readable input.

### Example output
Config generated from my Garden instance:
```
resource "retool_folder" "app_folder_" {
  id = "app_116"
  name = "П"
  folder_type = "app"
}

resource "retool_folder" "app_folder__1" {
  id = "app_117"
  name = "Р"
  folder_type = "app"
}

resource "retool_folder" "app_folder__2" {
  id = "app_118"
  name = "С"
  folder_type = "app"
}

resource "retool_folder" "app_folder__3" {
  id = "app_254"
  name = "У"
  folder_type = "app"
  parent_folder_id = retool_folder.app_folder_.id
}

resource "retool_folder" "app_folder__4" {
  id = "app_255"
  name = "Ф"
  folder_type = "app"
  parent_folder_id = retool_folder.app_folder_.id
}

resource "retool_folder" "app_folder__5" {
  id = "app_256"
  name = "Х"
  folder_type = "app"
  parent_folder_id = retool_folder.app_folder__4.id
}

resource "retool_folder" "components" {
  id = "app_6"
  name = "Components"
  folder_type = "app"
}

resource "retool_folder" "navigation" {
  id = "app_7"
  name = "Navigation"
  folder_type = "app"
  parent_folder_id = retool_folder.components.id
}

resource "retool_folder" "sample" {
  id = "resource_2"
  name = "sample"
  folder_type = "resource"
}

resource "retool_folder" "dev" {
  id = "resource_3"
  name = "dev"
  folder_type = "resource"
}

resource "retool_folder" "shared" {
  id = "resource_4"
  name = "shared"
  folder_type = "resource"
}

resource "retool_group" "some_group_cab941bf-469f-4b4a-aa02-699e0adc8574" {
  name = "Some Group cab941bf-469f-4b4a-aa02-699e0adc8574"
  universal_app_access = "edit"
  universal_resource_access = "own"
  universal_workflow_access = "use"
  universal_query_library_access = "none"
  user_list_access = false
  audit_log_access = false
  unpublished_release_access = false
  usage_analytics_access = false
  account_details_access = true
  landing_page_app_id = "065999e8-802b-11ee-8726-87ebc9a6fbaa"
}

resource "retool_group" "test_group" {
  name = "test group"
  universal_app_access = "none"
  universal_resource_access = "none"
  universal_workflow_access = "none"
  universal_query_library_access = "edit"
  user_list_access = false
  audit_log_access = false
  unpublished_release_access = true
  usage_analytics_access = false
  account_details_access = true
}

resource "retool_permissions" "some_group_cab941bf-469f-4b4a-aa02-699e0adc8574_permissions" {
  subject = {
    type = "group"
    id = retool_group.some_group_cab941bf-469f-4b4a-aa02-699e0adc8574.id
  }
  permissions = [
    {
      object = {
        type = "app"
        id = "00ae70f4-5fca-11ed-bc31-bb95f413afad"
      }
      access_level = "edit"
    },
   ...
    {
      object = {
        type = "folder"
        id = retool_folder.shared.id
      }
      access_level = "own"
    },
    {
      object = {
        type = "folder"
        id = "workflow_3"
      }
      access_level = "use"
    },
    {
      object = {
        type = "folder"
        id = "workflow_4"
      }
      access_level = "use"
    },
    {
      object = {
        type = "resource_configuration"
        id = "09ba93d2-eb35-4075-9ba0-f019a177d97e"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource_configuration"
        id = "f1311f8a-ce34-4584-8772-e0582b00682d"
      }
      access_level = "own"
    },
  ]
}

resource "retool_permissions" "test_group_permissions" {
  subject = {
    type = "group"
    id = retool_group.test_group.id
  }
  permissions = [
    {
      object = {
        type = "app"
        id = "065999e8-802b-11ee-8726-87ebc9a6fbaa"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "0659eac4-802b-11ee-b78d-c3254732c019"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "2f342d7e-51f9-11ea-84b4-2f5394df120c"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "3b3100de-1261-11ea-8511-f710a7adfcf3"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "40da2fa4-54b4-11ed-bbdf-77799c000a1f"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "4bb42ada-2ae6-11ed-a212-43470680e7c6"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "5a446a26-f808-11ec-8eac-e781a531de57"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "65578aa6-ac39-11e9-aa84-bf0fe9957eaa"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "8bd21ec6-563b-11ed-8ea2-9fe48680e47b"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "935bb284-98f2-11ed-8a7a-a7714e6d3854"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "abc3ee10-c2b2-11ed-916d-7742ad94a03c"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "b33e60c0-116d-11ea-8c85-a368dd700d7c"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "c37676ba-116f-11ea-b17d-d7734e1526f2"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "c696a9be-125f-11ea-90ba-af055aec884f"
      }
      access_level = "use"
    },
    {
      object = {
        type = "app"
        id = "d822bb2e-5b17-11ed-99ae-ab90366cb90f"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "e0d7eb94-125f-11ea-9ed8-978bf234afa0"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "e6a766b4-2592-11ed-8bb5-7741d84799bd"
      }
      access_level = "own"
    },
    {
      object = {
        type = "app"
        id = "edf2d8d8-ba05-11ed-ba0a-6fa3ec081f90"
      }
      access_level = "own"
    },
    {
      object = {
        type = "folder"
        id = retool_folder.sample.id
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource"
        id = "509115aa-35ba-4369-b44a-c9a54deac8d6"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource"
        id = "606ab181-0910-45f3-a9a6-16fc93e21707"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource"
        id = "bae176ec-7f67-4940-b206-a24d60fbe2ce"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource"
        id = "c80285d0-459e-47f7-9a03-7523b88ad735"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource_configuration"
        id = "30183c15-fb88-4875-9130-be1a339e9dc2"
      }
      access_level = "own"
    },
    {
      object = {
        type = "resource_configuration"
        id = "72156ee3-cd9c-41f3-b378-c152c9c1a2e6"
      }
      access_level = "own"
    },
  ]
}

```

Note the places where we reference other folders and groups:
```
...
  parent_folder_id = retool_folder.components.id
...
  subject = {
    type = "group"
    id = retool_group.test_group.id
  }
```
Also note that the config still has a lot of hardcoded object ids, e.g. for apps and resources, but there's not much we can do about it.