### PR TITLE
[feat] Auto-generate Terraform config for retool_source_control resource

### DIFF
--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -9,13 +9,15 @@ import {
   generateTerraformConfigForGroups,
   generateTerraformConfigForPermissions,
   generateTerraformConfigForSSO,
+  generateTerraformConfigForSourceControl,
   importRetoolConfig
 } from "../utils/terraformGen";
 import type { 
   TerraformFolderImport, 
   TerraformGroupImport, 
   TerraformPermissionsImport, 
-  TerraformSSOImport 
+  TerraformSSOImport, 
+  TerraformSourceControlImport 
 } from "../utils/terraformGen";
 
 
@@ -74,11 +76,15 @@ import {
     const groupResources = config.filter((resource) => resource.resourceType === "retool_group") as TerraformGroupImport[];
     const permissionResources = config.filter((resource) => resource.resourceType === "retool_permissions") as TerraformPermissionsImport[];
     const ssoResources = config.filter((resource) => resource.resourceType === "retool_sso") as TerraformSSOImport[];
+    const sourceControlResources = config.filter((resource) => resource.resourceType === "retool_source_control") as TerraformSourceControlImport[];
     let lines = await generateTerraformConfigForFolders(folderResources);
     lines = lines.concat(generateTerraformConfigForGroups(groupResources));
     lines = lines.concat(await generateTerraformConfigForPermissions(permissionResources, config));
     if (ssoResources.length > 0) {
       lines = lines.concat(generateTerraformConfigForSSO(ssoResources[0]));
+    }
+    if (sourceControlResources.length > 0) {
+      lines = lines.concat(generateTerraformConfigForSourceControl(sourceControlResources[0]));
     }
     // Print everything into a file
     fs.writeFileSync(argv.config, lines.join("\n"));


### PR DESCRIPTION
### What
Adding auto-generation of `retool_source_control` resource.

### Example output
```
resource "retool_source_control" "source_control" {
  org = "tryretool"
  repo = "dzmitry"
  default_branch = "main"
  repo_version = "1.0.0"
  github = {
    app_authentication = {
      app_id = "12334523"
      installation_id = "123145645"
      private_key = null # Replace with your private key
    }
    url = "https://github.retool.com"
    enterprise_api_url = "https://github.retool.com/api/v3"
  }
}
```